### PR TITLE
Add August poll from Sifo

### DIFF
--- a/Data/Polls.csv
+++ b/Data/Polls.csv
@@ -1,4 +1,5 @@
 PublYearMonth,Company,M,L,C,KD,S,V,MP,SD,FI,Uncertain,n,PublDate,collectPeriodFrom,collectPeriodTo,approxPeriod,house
+2021-aug,Sifo,21.8,2.7,8.6,4.9,24.1,11.9,4.2,20.5,NA,13.0,5357,2021-08-20,2021-08-09,2021-08-19,FALSE,Sifo
 2021-aug,Demoskop,23.2,2.3,10.1,5.4,24.6,10.2,3.5,19.9,NA,NA,2403,2021-08-10,2021-08-02,2021-08-05,FALSE,Demoskop
 2021-aug,Sentio,18.9,4.1,6.8,5.1,23.6,10.8,5.0,23.9,NA,NA,NA,2021-08-05,2021-07-20,2021-07-28,TRUE,Sentio
 2021-jul,Novus,21.0,2.2,8.9,4.5,23.8,13.3,3.8,21.6,NA,NA,2480,2021-07-28,2021-07-19,2021-07-26,FALSE,Novus


### PR DESCRIPTION
This PR adds the August poll from SvD/Sifo.

Source: https://www.kantarsifo.se/sites/default/files/reports/documents/vb_aug_2021.pdf