### PR TITLE
Add Skop September 2021

### DIFF
--- a/Data/Polls.csv
+++ b/Data/Polls.csv
@@ -1,4 +1,5 @@
 PublYearMonth,Company,M,L,C,KD,S,V,MP,SD,FI,Uncertain,n,PublDate,collectPeriodFrom,collectPeriodTo,approxPeriod,house
+2021-sep,Skop,21.6,2.4,9.6,5.0,25.8,12.5,3.4,18.5,NA,NA,1030,2021-09-16,2021-09-03,2021-09-11,FALSE,Skop
 2021-sep,Demoskop,22.1,2.5,9.7,5.6,26.7,8.2,3.5,20.7,NA,NA,2199,2021-09-10,2021-08-31,2021-09-08,FALSE,Demoskop
 2021-sep,Novus,22.0,2.1,8.9,4.5,25.9,11.2,4.4,19.6,NA,NA,4765,2021-09-02,2021-08-02,2021-08-29,FALSE,Novus
 2021-aug,Ipsos,21,3,8,4,25,11,5,20,NA,11,1616,2021-08-24,2021-08-10,2021-08-23,FALSE,Ipsos


### PR DESCRIPTION
This PR adds Skop poll from September 2021. Source: https://skop.se/politik/2021/09/skops-valjarbarometer-den-16-september-2021/